### PR TITLE
Revert "Calculate angle for major ticks based on actual values"

### DIFF
--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -327,9 +327,7 @@ function drawRadialMajorTicks(context, options) {
 
 /* istanbul ignore next: private, not testable */
 function radialNextAngle(options, i, s) {
-    let max = options.maxValue;
-    let currentTick = options.majorTicks[i];
-    return options.startAngle + options.ticksAngle / max * currentTick;
+    return options.startAngle + i * (options.ticksAngle / (s - 1));
 }
 
 /* istanbul ignore next: private, not testable */


### PR DESCRIPTION
Reverts Mikhus/canvas-gauges#92, because examples are broken. Need more investigations on this.