### PR TITLE
Feature/customize

### DIFF
--- a/lib/GenericOptions.js
+++ b/lib/GenericOptions.js
@@ -153,6 +153,7 @@ const GenericOptions = {
         { from: 60, to: 80, color: '#ccc' },
         { from: 80, to: 100, color: '#999' }],
     highlightsWidth: 15,
+    highlightsLineCap: 'butt',
 
     // progress bar
     barWidth: 20, // percents

--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -449,11 +449,9 @@ function drawRadialTitle(context, options) {
 const validMember = /{([_a-zA-Z]+[_a-zA-Z0-9]*)}/g
 function formatContext(options, format) {
     // "{value} % {Title}"
-    console.log({options}, {format});
     
     return format.replace(validMember, function (match, member){
         const value = options[member];
-        console.log({match}, {member}, {value});
         return (typeof value !== 'undefined') ? value : match;
     })
 }

--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -224,6 +224,7 @@ function drawRadialHighlights(context, options) {
         );
         context.strokeStyle = hlt.color;
         context.lineWidth = hlWidth;
+        context.lineCap = options.highlightsLineCap;
         context.stroke();
         context.closePath();
 
@@ -445,6 +446,17 @@ function drawRadialTitle(context, options) {
     context.restore();
 }
 
+const validMember = /{([_a-zA-Z]+[_a-zA-Z0-9]*)}/g
+function formatContext(options, format) {
+    // "{value} % {Title}"
+    console.log({options}, {format});
+    
+    return format.replace(validMember, function (match, member){
+        const value = options[member];
+        console.log({match}, {member}, {value});
+        return (typeof value !== 'undefined') ? value : match;
+    })
+}
 /* istanbul ignore next: private, not testable */
 /**
  * Draws units name on the gauge
@@ -460,7 +472,7 @@ function drawRadialUnits(context, options) {
     context.font = drawings.font(options, 'Units', context.max / 200);
     context.fillStyle = options.colorUnits;
     context.textAlign = 'center';
-    context.fillText(options.units, 0, context.max / 3.25, context.max * 0.8);
+    context.fillText(formatContext(options, options.units), 0, context.max / 3.25, context.max * 0.8);
     context.restore();
 }
 


### PR DESCRIPTION
The changes we made are:
1.	Adding an option “highlightsLineCap” which can be one of the following: ‘round’, ‘square’ or ‘butt’. (default is ‘butt’)
It sets the context.lineCap within the drawRadialHighLights function of the RadialGauge object.
2.	Adding a format option to set the “units” attribute. 
For example “{value} % {title}” which replaces the attributes inside {} to the same member in the option object.
So if title is set to “Hour” and value to “50” the units will be “50% Hour”.
